### PR TITLE
Adjust log paths and compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,10 @@ services:
       - IA_TIMEZONE=America/Los_Angeles
       - IA_MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY}
       - IA_LOG_FOLDER=/app/backend/logs
+      - IA_SYSTEM_LOG_TIMEZONE=America/Los_Angeles
     volumes:
-      - ./fail2ban_logs/fail2ban.log:/app/backend/logs/fail2ban.log:ro
-      - ./fail2ban_logs/fail2ban.log.1:/app/backend/logs/fail2ban.log.1:ro
-      - ./fail2ban_logs/fail2ban.log.2.gz:/app/backend/logs/fail2ban.log.2.gz:ro
-      - ./fail2ban_logs/fail2ban.log.3.gz:/app/backend/logs/fail2ban.log.3.gz:ro
-      - ./fail2ban_logs/fail2ban.log.4.gz:/app/backend/logs/fail2ban.log.4.gz:ro
+      - ./fail2ban_logs:/app/backend/data/logs:ro
+      - /var/log/fail2ban.log:/app/backend/data/logs/fail2ban.log:ro
     ports:
       - "0.0.0.0:8080:8080"
     security_opt:
@@ -27,7 +25,7 @@ services:
       context: ./nginx-log-normalizer
       dockerfile: Dockerfile
     volumes:
-      - ./nginx_logs:/logs
+      - /home/ryancox/AiRC-Frontend/data/nginx/logs/proxy-host-1_access.log:/srv/logs/access.log:ro
       - ./normalized_logs:/normalized
     command: python3 /app/normalize_nginx_log.py
 
@@ -35,20 +33,16 @@ services:
     image: allinurl/goaccess:latest
     container_name: goaccess-report
     volumes:
-      - ./normalized_logs:/logs:ro
+      - /home/ryancox/AiRC-Frontend/data/nginx/logs/proxy-host-1_access.log:/srv/logs/access.log:ro
       - ./report:/report
     command: >
-      goaccess /logs/access.normalized.log
-      --log-format=COMBINED
-      --date-format=%d/%b/%Y
-      --time-format=%T
-      --real-time-html
-      --output=/report/index.html
+      goaccess /srv/logs/access.log --log-format=COMBINED -o /report/index.html
 
   log-normalizer:
     build:
       context: ./log-normalizer
       dockerfile: Dockerfile
     volumes:
-      - ./fail2ban_logs:/logs
+      - ./fail2ban_logs:/app/backend/data/logs:ro
+      - /var/log/fail2ban.log:/app/backend/data/logs/fail2ban.log:ro
       - ./normalized_logs:/normalized

--- a/nginx-log-normalizer/normalize_nginx_log.py
+++ b/nginx-log-normalizer/normalize_nginx_log.py
@@ -13,7 +13,10 @@ import time
 from typing import Generator, Optional
 
 
-INPUT_LOG = "fail2ban_logs/proxy-host-1_access.log"
+# Path inside the container where the nginx access log is mounted. This path
+# corresponds with the volume defined for the ``goaccess-report`` service in
+# ``docker-compose.yml``.
+INPUT_LOG = "/srv/logs/access.log"
 OUTPUT_LOG = "normalized/proxy-host-1_access.normalized.log"
 
 # Matches the timestamp, status code and client IP address from a standard

--- a/normalize_nginx_log.py
+++ b/normalize_nginx_log.py
@@ -13,7 +13,9 @@ import time
 from typing import Generator, Optional
 
 
-INPUT_LOG = "fail2ban_logs/proxy-host-1_access.log"
+# Path inside the container where the nginx access log is mounted. This is
+# mapped from the host in ``docker-compose.yml``.
+INPUT_LOG = "/srv/logs/access.log"
 OUTPUT_LOG = "normalized/proxy-host-1_access.normalized.log"
 
 # Matches the timestamp, status code and client IP address from a standard


### PR DESCRIPTION
## Summary
- use `/srv/logs/access.log` for nginx log processing
- update fail2ban log normalizer to read `/app/backend/data/logs/fail2ban.log`
- mount correct paths in `docker-compose.yml`
- set `IA_SYSTEM_LOG_TIMEZONE` env variable

## Testing
- `composer install`
- `composer test` *(fails: CONNECT tunnel failed, response 403)*
- `composer lint` *(fails: phpstan found 2 errors)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c17121d9483308ad11a66c97c6136